### PR TITLE
cleanup(resourceGroup): adds some javadoc. ResourceGroupType toUpper.

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -225,7 +225,7 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
                             username, resourceName, resourceType),
                         () ->
                             fiatService.hasAuthorization(
-                                username, resourceType, resourceName, "CREATE"));
+                                username, resourceType, resourceName, Authorization.CREATE.name()));
                   })
               .call();
       if (response.getStatus() == HttpServletResponse.SC_OK) {

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/groups/ResourceGroup.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/groups/ResourceGroup.java
@@ -23,16 +23,35 @@ import com.netflix.spinnaker.fiat.model.resources.Resource;
 import com.netflix.spinnaker.fiat.model.resources.ResourceType;
 import lombok.Data;
 
+/**
+ * A ResourceGroup provides additional rule-based permissions to resources.
+ *
+ * <p>A ResourceGroup allows for encoding of permissions for an AccessControlled resource where
+ * those permissions can be derived from that resource rather than explicitly encoded as properties
+ * on the resource.
+ *
+ * <p>As a concrete example, {@see PrefixResourceGroup} which allows for defining common permissions
+ * on resources that start with a common prefix.
+ */
 @Data
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "resourceGroupType")
-@JsonSubTypes(@JsonSubTypes.Type(value = PrefixResourceGroup.class, name = "Prefix"))
+@JsonSubTypes(@JsonSubTypes.Type(value = PrefixResourceGroup.class, name = "PREFIX"))
 public abstract class ResourceGroup {
+  /**
+   * Whether the supplied resource matches this ResourceGroup.
+   *
+   * @param resource the resource to check
+   * @return true if the permissions on this ResourceGroup should be applied to the resource.
+   */
   public abstract boolean contains(Resource.AccessControlled resource);
 
+  /** The type of resource this ResourceGroup applies to. */
   private ResourceType resourceType;
 
+  /** The concrete type of this ResourceGroup. */
   // needed for serialization
   private ResourceGroupType resourceGroupType;
 
+  /** The Permissions that should get added to resources that match this ResourceGroup. */
   private Permissions permissions = Permissions.EMPTY;
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/groups/ResourceGroupType.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/groups/ResourceGroupType.java
@@ -17,5 +17,5 @@
 package com.netflix.spinnaker.fiat.model.resources.groups;
 
 public enum ResourceGroupType {
-  Prefix
+  PREFIX
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/resourcegroups/GroupResolutionStrategy.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/resourcegroups/GroupResolutionStrategy.java
@@ -21,6 +21,10 @@ import com.netflix.spinnaker.fiat.model.resources.Resource;
 import com.netflix.spinnaker.fiat.model.resources.groups.ResourceGroup;
 import java.util.Set;
 
+/**
+ * A GroupResolutionStrategy is responsible supplying the final set of Permissions for a Resource
+ * taking into consider any matching ResourceGroups.
+ */
 public interface GroupResolutionStrategy {
   /**
    * Resolve the permissions of the resource taking group permissions and resource permissions into


### PR DESCRIPTION
Moved ResourceGroupType enum to uppercase for consistency with other enums in (resource type and authorization)
